### PR TITLE
attachments functionality- #294

### DIFF
--- a/backend/api/attachment.py
+++ b/backend/api/attachment.py
@@ -1,0 +1,52 @@
+import os
+
+from django.http import JsonResponse
+from django.views.decorators.csrf import csrf_exempt
+
+from user import authentication
+from . import utils
+from user.models import *
+from project.models import *
+
+
+@csrf_exempt
+def attachment_handler(request):
+    token = request.META.get('HTTP_AUTHORIZATION', None)
+    if not(token and authentication.is_authenticated(token)):
+        return JsonResponse({
+            "response": False,
+            "error": "Unauthorized"
+        })
+    attach_to = request.GET.get('id', authentication.get_user_id(token))
+    if Portfolio.objects(id=attach_to):
+        attached = Portfolio.objects.get(id=attach_to)
+    elif Project.objects(id=attach_to):
+        attached = Project.objects.get(id=attach_to)
+    elif Milestone.objects(id=attach_to):
+        attached = Milestone.objects.get(id=attach_to)
+    else:
+        attached = None
+    if request.method == 'POST':
+        try:
+            for file in request.FILES:
+                utils.handle_uploaded_file('attachments/'+attach_to, request.FILES[file], str(request.FILES[file]))
+                attached.attachments.append(str(request.FILES[file]))
+            attached.save()
+        except Exception as e:
+            return JsonResponse({'response': False, 'error': str(e)})
+        return JsonResponse({'response': True})
+    elif request.method == 'DELETE':
+        try:
+            delete_this=request.GET.get('file_name', None)
+            if delete_this:
+                attached.attachments.remove(str(delete_this))
+                os.remove('media/attachments/'+attach_to+'/'+delete_this)
+                attached.save()
+        except Exception as e:
+            return JsonResponse({'response': False, 'error': str(e)})
+        return JsonResponse({'response': True})
+    else:
+        return JsonResponse({
+            "response": False,
+            "error": "Wrong request method"
+        })

--- a/backend/api/urls.py
+++ b/backend/api/urls.py
@@ -18,9 +18,11 @@ from django.urls import include,path
 from django.conf.urls import url
 from django.conf import settings
 from django.conf.urls.static import static
+from . import attachment
 
 urlpatterns = [
     path('admin/', admin.site.urls),
     url(r'^api/user/', include('user.urls')),
-    url(r'^api/project/', include('project.urls'))
+    url(r'^api/project/', include('project.urls')),
+    path('api/attachment/', attachment.attachment_handler, name="attachment"),
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/backend/api/utils.py
+++ b/backend/api/utils.py
@@ -1,7 +1,10 @@
+import os
+
 from project import models as project_models
 from user import models as user_models
 from django.db.models import Avg, Window
 from datetime import datetime
+
 
 def user_json(user, user_id=""):
     obj = {}
@@ -36,6 +39,10 @@ def user_json(user, user_id=""):
 
 def project_json(project,user_id):
     obj = {}
+    attachments = []
+    for att in project.attachments:
+        attachments.append(att)
+    obj['attachments']=attachments
     obj['project_id'] = str(project.id)
     obj['title'] = project.title
     obj['budget'] = project.budget
@@ -57,14 +64,7 @@ def project_json(project,user_id):
     obj['milestones'] = []
     milestones = project_models.Milestone.objects.filter(project=project).order_by('deadline')
     for milestone in milestones:
-        obj['milestones'].append({
-            "id": str(milestone.id),
-            "name": milestone.name,
-            "detail": milestone.detail,
-            "deadline": format_datetime(milestone.deadline),
-            "status": milestone.status,
-            "is_final": milestone.is_final
-        })
+        obj['milestones'].append(milestone_json(milestone))
     return obj
 
 
@@ -129,6 +129,9 @@ def hide_name(name):
 
 def portfolio_json(portfolio, from_model=""):
     obj = {}
+    attachments = []
+    for att in portfolio.attachments:
+        attachments.append(att)
     obj['id'] = str(portfolio.id)
     obj['title'] = portfolio.title
     obj['description'] = portfolio.description
@@ -140,21 +143,42 @@ def portfolio_json(portfolio, from_model=""):
             'full_name': portfolio.user.full_name,
             'profile_image': portfolio.user.profile_image
         }
+    obj['attachments'] = attachments
     obj['project_id'] = portfolio.project_id
     obj['created_at'] = format_datetime(portfolio.created_at)
     obj['updated_at'] = format_datetime(portfolio.updated_at)
     return obj
 
+
 def milestone_json(milestone):
+    attachments = []
+    for att in milestone.attachments:
+        attachments.append(att)
     return {
         "id": str(milestone.id),
         "name": milestone.name,
         "detail": milestone.detail,
         "deadline": format_datetime(milestone.deadline),
         "status": milestone.status,
+        "attachments": attachments,
         "is_final": milestone.is_final,
         "project_id": str(milestone.project.id)
     }
 
+
 def format_datetime(dt):
     return dt.strftime("%Y-%m-%d")
+
+
+def handle_uploaded_file(app_name, file, filename):
+    if not os.path.exists('media/'):
+        os.mkdir('media/')
+    cumulative = 'media/'
+    for name in app_name.rsplit('/'):
+        cumulative = os.path.join(cumulative, name)
+        if not os.path.exists(cumulative):
+            os.mkdir(cumulative)
+
+    with open(cumulative + '/' + filename, 'wb+') as destination:
+        for chunk in file.chunks():
+            destination.write(chunk)

--- a/backend/project/models.py
+++ b/backend/project/models.py
@@ -37,6 +37,7 @@ class Project(BaseDocument):
     title = StringField(max_length=50)
     budget = FloatField(min_value=0)
     milestones = DictField(null=True)
+    attachments = ListField(default=[])
     status = IntField()  # 0 bidding period, 1 project awarded to a freelancer, 2 project completed, -1 project discarded
 
     meta = {'collection': 'projects',
@@ -72,6 +73,5 @@ class Milestone(BaseDocument):
     status = IntField(default=0)  # -1 discarded 0 ongoing, 1 in review, 2 changes requested, 3 done
     attachments = ListField(default=[])
     is_final = BooleanField(default=False)
-
 
     meta = {'collection': 'milestones'}

--- a/backend/user/models.py
+++ b/backend/user/models.py
@@ -62,6 +62,7 @@ class Portfolio(BaseDocument):
     description = StringField()
     user = ReferenceField('User', required=True)
     date = DateTimeField()
+    attachments = ListField(default=[])
     project_id = StringField(blank=True, null=True)
 
     meta = {'collection': 'portfolios'}

--- a/backend/user/views.py
+++ b/backend/user/views.py
@@ -122,7 +122,7 @@ def profile_handler(request):
             except Exception as e:
                 return JsonResponse({'response': False, 'error': str(e)})
         else:
-            return JsonResponse({"response": False, "error": "Unauthorized"})
+            return JsonResponse({"response": False, "error": "Unauthorized1"})
     elif request.method == 'PUT':
         if token and authentication.is_authenticated(token):
             body = json.loads(request.body.decode('utf-8'))
@@ -142,23 +142,9 @@ def profile_handler(request):
     })
 
 
-ALLOWED_EXTENSIONS = {'png', 'jpg', 'jpeg'}
-
-
 def allowed_file(filename):
     return '.' in filename and \
-           filename.rsplit('.', 1)[1].lower() in ALLOWED_EXTENSIONS
-
-
-def handle_uploaded_file(app_name, file, filename):
-    if not os.path.exists('media/'):
-        os.mkdir('media/')
-    if not os.path.exists('media/'+app_name):
-        os.mkdir('media/'+app_name)
-
-    with open('media/' + app_name + '/' + filename, 'wb+') as destination:
-        for chunk in file.chunks():
-            destination.write(chunk)
+           filename.rsplit('.', 1)[1].lower() in {'png', 'jpg', 'jpeg'}
 
 
 @csrf_exempt


### PR DESCRIPTION
#294 
POST:
```/api/attachment/?id=<project_id or milestone_id or portfolio_id>```
add sent files as attachments. Same endpoint works for projects, milestones and portfolios.

DELETE:
```/api/attachment/?id=<project_id or milestone_id or portfolio_id>&file_name=<filename>```
deletes given file and removes the file from attachments.

Necessary changes on returned JSON files has been made. Now getters of projects, milestones and portfolios shows attachments.